### PR TITLE
 隔离策略为线程时bug

### DIFF
--- a/discovery-plugin-strategy-starter-zuul/src/main/java/com/nepxion/discovery/plugin/strategy/zuul/adapter/DefaultDiscoveryEnabledAdapter.java
+++ b/discovery-plugin-strategy-starter-zuul/src/main/java/com/nepxion/discovery/plugin/strategy/zuul/adapter/DefaultDiscoveryEnabledAdapter.java
@@ -11,19 +11,20 @@ package com.nepxion.discovery.plugin.strategy.zuul.adapter;
 
 import com.nepxion.discovery.common.constant.DiscoveryConstant;
 import com.nepxion.discovery.plugin.strategy.adapter.AbstractDiscoveryEnabledAdapter;
+import com.nepxion.discovery.plugin.strategy.zuul.configuration.ContextHolder;
 import com.netflix.zuul.context.RequestContext;
 
 public class DefaultDiscoveryEnabledAdapter extends AbstractDiscoveryEnabledAdapter {
     @Override
     protected String getVersionValue() {
-        RequestContext context = RequestContext.getCurrentContext();
+        ContextHolder context = ContextHolder.getCurrentContext();
 
         return context.getRequest().getHeader(DiscoveryConstant.VERSION);
     }
 
     @Override
     protected String getRegionValue() {
-        RequestContext context = RequestContext.getCurrentContext();
+        ContextHolder context = ContextHolder.getCurrentContext();
 
         return context.getRequest().getHeader(DiscoveryConstant.REGION);
     }

--- a/discovery-plugin-strategy-starter-zuul/src/main/java/com/nepxion/discovery/plugin/strategy/zuul/configuration/ContextHolder.java
+++ b/discovery-plugin-strategy-starter-zuul/src/main/java/com/nepxion/discovery/plugin/strategy/zuul/configuration/ContextHolder.java
@@ -1,0 +1,53 @@
+package com.nepxion.discovery.plugin.strategy.zuul.configuration;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ContextHolder extends HashMap<String, Object> {
+    private static final ThreadLocal<ContextHolder> THREAD_LOCAL = new InheritableThreadLocal<ContextHolder>() {
+        @Override
+        protected ContextHolder initialValue() {
+            try {
+                return new ContextHolder();
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        }
+    };
+    private static ContextHolder contextHolder;
+
+    public static ContextHolder getCurrentContext() {
+        if (contextHolder != null) return contextHolder;
+        ContextHolder context = THREAD_LOCAL.get();
+        return context;
+    }
+
+    public void addZuulRequestHeader(String name, String value) {
+        getZuulRequestHeaders().put(name.toLowerCase(), value);
+    }
+
+    public Map<String, String> getZuulRequestHeaders() {
+        if (get("zuulRequestHeaders") == null) {
+            HashMap<String, String> zuulRequestHeaders = new HashMap<String, String>();
+            putIfAbsent("zuulRequestHeaders", zuulRequestHeaders);
+        }
+        return (Map<String, String>) get("zuulRequestHeaders");
+    }
+    public void setRequest(HttpServletRequest request) {
+        put("request", request);
+    }
+
+    public HttpServletRequest getRequest() {
+        return (HttpServletRequest) get("request");
+    }
+
+
+    public void setRequestQueryParams(Map<String, List<String>> qp) {
+        put("requestQueryParams", qp);
+    }
+    public Map<String, List<String>> getRequestQueryParams() {
+        return (Map<String, List<String>>) get("requestQueryParams");
+    }
+}

--- a/discovery-plugin-strategy-starter-zuul/src/main/java/com/nepxion/discovery/plugin/strategy/zuul/configuration/RequestContextHystrixAutoConfiguration.java
+++ b/discovery-plugin-strategy-starter-zuul/src/main/java/com/nepxion/discovery/plugin/strategy/zuul/configuration/RequestContextHystrixAutoConfiguration.java
@@ -1,0 +1,44 @@
+package com.nepxion.discovery.plugin.strategy.zuul.configuration;
+
+import com.netflix.hystrix.Hystrix;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+import com.netflix.hystrix.strategy.executionhook.HystrixCommandExecutionHook;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisher;
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+
+@Configuration
+@ConditionalOnClass({ Hystrix.class})
+public class RequestContextHystrixAutoConfiguration {
+    @Autowired(required = false)
+    private HystrixConcurrencyStrategy existingConcurrencyStrategy;
+
+    @PostConstruct
+    public void init() {
+        // Keeps references of existing Hystrix plugins.
+        HystrixEventNotifier eventNotifier = HystrixPlugins.getInstance()
+                .getEventNotifier();
+        HystrixMetricsPublisher metricsPublisher = HystrixPlugins.getInstance()
+                .getMetricsPublisher();
+        HystrixPropertiesStrategy propertiesStrategy = HystrixPlugins.getInstance()
+                .getPropertiesStrategy();
+        HystrixCommandExecutionHook commandExecutionHook = HystrixPlugins.getInstance()
+                .getCommandExecutionHook();
+
+        HystrixPlugins.reset();
+
+        // Registers existing plugins excepts the Concurrent Strategy plugin.
+        HystrixPlugins.getInstance().registerConcurrencyStrategy(
+                new RequestContextHystrixConcurrencyStrategy(existingConcurrencyStrategy));
+        HystrixPlugins.getInstance().registerEventNotifier(eventNotifier);
+        HystrixPlugins.getInstance().registerMetricsPublisher(metricsPublisher);
+        HystrixPlugins.getInstance().registerPropertiesStrategy(propertiesStrategy);
+        HystrixPlugins.getInstance().registerCommandExecutionHook(commandExecutionHook);
+    }
+}

--- a/discovery-plugin-strategy-starter-zuul/src/main/java/com/nepxion/discovery/plugin/strategy/zuul/configuration/RequestContextHystrixConcurrencyStrategy.java
+++ b/discovery-plugin-strategy-starter-zuul/src/main/java/com/nepxion/discovery/plugin/strategy/zuul/configuration/RequestContextHystrixConcurrencyStrategy.java
@@ -1,0 +1,81 @@
+package com.nepxion.discovery.plugin.strategy.zuul.configuration;
+
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariable;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableLifecycle;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
+import com.netflix.zuul.context.RequestContext;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class RequestContextHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
+    private HystrixConcurrencyStrategy delegate;
+
+    public RequestContextHystrixConcurrencyStrategy(HystrixConcurrencyStrategy delegate) {
+        this.delegate=delegate;
+    }
+
+    @Override
+    public BlockingQueue<Runnable> getBlockingQueue(int maxQueueSize) {
+        return delegate != null
+                ? delegate.getBlockingQueue(maxQueueSize)
+                : super.getBlockingQueue(maxQueueSize);
+    }
+
+    @Override
+    public <T> HystrixRequestVariable<T> getRequestVariable(
+            HystrixRequestVariableLifecycle<T> rv) {
+        return delegate != null
+                ? delegate.getRequestVariable(rv)
+                : super.getRequestVariable(rv);
+    }
+
+    @Override
+    public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+                                            HystrixProperty<Integer> corePoolSize,
+                                            HystrixProperty<Integer> maximumPoolSize,
+                                            HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
+                                            BlockingQueue<Runnable> workQueue) {
+        return delegate != null
+                ? delegate.getThreadPool(threadPoolKey, corePoolSize,
+                maximumPoolSize, keepAliveTime, unit, workQueue)
+                : super.getThreadPool(threadPoolKey, corePoolSize, maximumPoolSize,
+                keepAliveTime, unit, workQueue);
+    }
+
+    @Override
+    public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolProperties threadPoolProperties) {
+        return delegate != null
+                ? delegate.getThreadPool(threadPoolKey, threadPoolProperties)
+                : super.getThreadPool(threadPoolKey, threadPoolProperties);
+    }
+    @Override
+    public <T> Callable<T> wrapCallable(Callable<T> callable) {
+        RequestContext before = RequestContext.getCurrentContext();
+        return new Callable<T>() {
+            @Override
+            public T call() throws Exception {
+                ContextHolder current = ContextHolder.getCurrentContext();
+                Set<Map.Entry<String, String>> entries = before.getZuulRequestHeaders().entrySet();
+                for (Map.Entry<String, String> entry : entries) {
+                    current.addZuulRequestHeader(entry.getKey(),entry.getValue());
+                }
+                current.setRequest(before.getRequest());
+                current.setRequestQueryParams(before.getRequestQueryParams());
+                try {
+                    return callable.call();
+                } finally {
+                    current.clear();
+                }
+            }
+        };
+
+    }
+}

--- a/discovery-plugin-strategy-starter-zuul/src/main/resources/META-INF/spring.factories
+++ b/discovery-plugin-strategy-starter-zuul/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 com.nepxion.discovery.plugin.strategy.configuration.StrategyAutoConfiguration,\
-com.nepxion.discovery.plugin.strategy.zuul.configuration.ZuulStrategyAutoConfiguration
+com.nepxion.discovery.plugin.strategy.zuul.configuration.ZuulStrategyAutoConfiguration,\
+com.nepxion.discovery.plugin.strategy.zuul.configuration.RequestContextHystrixAutoConfiguration

--- a/discovery-springcloud-example-zuul/src/main/java/com/nepxion/discovery/plugin/example/zuul/impl/MyDiscoveryEnabledStrategy.java
+++ b/discovery-springcloud-example-zuul/src/main/java/com/nepxion/discovery/plugin/example/zuul/impl/MyDiscoveryEnabledStrategy.java
@@ -11,6 +11,7 @@ package com.nepxion.discovery.plugin.example.zuul.impl;
 
 import java.util.Map;
 
+import com.nepxion.discovery.plugin.strategy.zuul.configuration.ContextHolder;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +32,7 @@ public class MyDiscoveryEnabledStrategy implements DiscoveryEnabledStrategy {
 
     // 根据Rest调用传来的Header参数（例如Token），选取执行调用请求的服务实例
     private boolean applyFromHeader(Server server, Map<String, String> metadata) {
-        RequestContext context = RequestContext.getCurrentContext();
+        ContextHolder context = ContextHolder.getCurrentContext();
         String token = context.getRequest().getHeader("token");
         // String value = context.getRequest().getParameter("value");
 

--- a/discovery-springcloud-example-zuul/src/main/resources/application.properties
+++ b/discovery-springcloud-example-zuul/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Spring cloud config
 spring.application.name=discovery-springcloud-example-zuul
 server.port=1400
-
+zuul.ribbon-isolation-strategy=thread
 # Eureka config for discovery
 eureka.instance.metadataMap.version=1.0
 eureka.instance.metadataMap.group=example-service-group


### PR DESCRIPTION
使用线程隔离灰度，空指针异常
zuul.ribbon-isolation-strategy=thread
线程隔离情况下无法获取requestContext中的值
