### PR TITLE
当需要调用的服务没有版本标签时，要根据header里面的策略是否有该服务的限制来进行判断

### DIFF
--- a/discovery-plugin-strategy/src/main/java/com/nepxion/discovery/plugin/strategy/adapter/DefaultDiscoveryEnabledAdapter.java
+++ b/discovery-plugin-strategy/src/main/java/com/nepxion/discovery/plugin/strategy/adapter/DefaultDiscoveryEnabledAdapter.java
@@ -103,12 +103,8 @@ public class DefaultDiscoveryEnabledAdapter implements DiscoveryEnabledAdapter {
             /*
         	 * 如果header对这个服务有版本要求，且服务标签为空，则反回false
         	 * 如果header对这个服务没有版本要求，且服务标签为空，则反回true
-        	 */
-        	if(StringUtils.isNotBlank(versions)) {
-        		 return false;
-        	}else {
-        		return true;
-        	}
+        	 */ 
+            return StringUtils.isBlank(versions);
         }
 
         // 如果精确匹配不满足，尝试用通配符匹配

--- a/discovery-plugin-strategy/src/main/java/com/nepxion/discovery/plugin/strategy/adapter/DefaultDiscoveryEnabledAdapter.java
+++ b/discovery-plugin-strategy/src/main/java/com/nepxion/discovery/plugin/strategy/adapter/DefaultDiscoveryEnabledAdapter.java
@@ -85,11 +85,6 @@ public class DefaultDiscoveryEnabledAdapter implements DiscoveryEnabledAdapter {
             return true;
         }
 
-        String version = pluginAdapter.getServerVersion(server);
-        if (StringUtils.isEmpty(version)) {
-            return true;
-        }
-
         String versions = null;
         try {
             Map<String, String> versionMap = JsonUtil.fromJson(versionValue, Map.class);
@@ -101,6 +96,19 @@ public class DefaultDiscoveryEnabledAdapter implements DiscoveryEnabledAdapter {
 
         if (StringUtils.isEmpty(versions)) {
             return true;
+        }
+        
+        String version = pluginAdapter.getServerVersion(server);
+        if (StringUtils.isEmpty(version)) {
+            /*
+        	 * 如果header对这个服务有版本要求，且服务标签为空，则反回false
+        	 * 如果header对这个服务没有版本要求，且服务标签为空，则反回true
+        	 */
+        	if(StringUtils.isNotBlank(versions)) {
+        		 return false;
+        	}else {
+        		return true;
+        	}
         }
 
         // 如果精确匹配不满足，尝试用通配符匹配


### PR DESCRIPTION
如果线上服务没有版本号，此时老服务不能被发现，应该要根据header里面的策略是否有该服务的限制来进行判断，如果header里面有策略要求，则按照策略去匹配，如果header里面没有该服务的策略，则这个没有版本号的服务应该也能被发现。