### PR TITLE
支持非http请求驱动的场景下，向后传递灰度策略

### DIFF
--- a/discovery-plugin-strategy/discovery-plugin-strategy-starter-service/src/main/java/com/nepxion/discovery/plugin/strategy/service/aop/FeignStrategyInterceptor.java
+++ b/discovery-plugin-strategy/discovery-plugin-strategy-starter-service/src/main/java/com/nepxion/discovery/plugin/strategy/service/aop/FeignStrategyInterceptor.java
@@ -6,6 +6,7 @@ package com.nepxion.discovery.plugin.strategy.service.aop;
  * <p>Copyright: Copyright (c) 2017-2050</p>
  * <p>Company: Nepxion</p>
  * @author Haojun Ren
+ * @author Fengfeng Li
  * @version 1.0
  */
 
@@ -76,27 +77,23 @@ public class FeignStrategyInterceptor extends AbstractStrategyInterceptor implem
 
     private void applyOuterHeader(RequestTemplate requestTemplate) {
         ServletRequestAttributes attributes = serviceStrategyContextHolder.getRestAttributes();
-        if (attributes == null) {
-            return;
-        }
-
-        HttpServletRequest previousRequest = attributes.getRequest();
-        Enumeration<String> headerNames = previousRequest.getHeaderNames();
-        if (headerNames == null) {
-            return;
-        }
-
-        while (headerNames.hasMoreElements()) {
-            String headerName = headerNames.nextElement();
-            String headerValue = previousRequest.getHeader(headerName);
-            boolean isHeaderContains = isHeaderContainsExcludeInner(headerName.toLowerCase());
-            if (isHeaderContains) {
-                if (feignCoreHeaderTransmissionEnabled) {
-                    requestTemplate.header(headerName, headerValue);
-                } else {
-                    boolean isCoreHeaderContains = StrategyUtil.isCoreHeaderContains(headerName);
-                    if (!isCoreHeaderContains) {
-                        requestTemplate.header(headerName, headerValue);
+        if (attributes != null) {
+            HttpServletRequest previousRequest = attributes.getRequest();
+            Enumeration<String> headerNames = previousRequest.getHeaderNames();
+            if (headerNames != null) {
+                while (headerNames.hasMoreElements()) {
+                    String headerName = headerNames.nextElement();
+                    String headerValue = previousRequest.getHeader(headerName);
+                    boolean isHeaderContains = isHeaderContainsExcludeInner(headerName.toLowerCase());
+                    if (isHeaderContains) {
+                        if (feignCoreHeaderTransmissionEnabled) {
+                            requestTemplate.header(headerName, headerValue);
+                        } else {
+                            boolean isCoreHeaderContains = StrategyUtil.isCoreHeaderContains(headerName);
+                            if (!isCoreHeaderContains) {
+                                requestTemplate.header(headerName, headerValue);
+                            }
+                        }
                     }
                 }
             }

--- a/discovery-plugin-strategy/discovery-plugin-strategy-starter-service/src/main/java/com/nepxion/discovery/plugin/strategy/service/aop/RestTemplateStrategyInterceptor.java
+++ b/discovery-plugin-strategy/discovery-plugin-strategy-starter-service/src/main/java/com/nepxion/discovery/plugin/strategy/service/aop/RestTemplateStrategyInterceptor.java
@@ -6,6 +6,7 @@ package com.nepxion.discovery.plugin.strategy.service.aop;
  * <p>Copyright: Copyright (c) 2017-2050</p>
  * <p>Company: Nepxion</p>
  * @author Haojun Ren
+ * @author Fengfeng Li
  * @version 1.0
  */
 
@@ -83,34 +84,31 @@ public class RestTemplateStrategyInterceptor extends AbstractStrategyInterceptor
 
     private void applyOuterHeader(HttpRequest request) {
         ServletRequestAttributes attributes = serviceStrategyContextHolder.getRestAttributes();
-        if (attributes == null) {
-            return;
-        }
-
-        HttpServletRequest previousRequest = attributes.getRequest();
-        Enumeration<String> headerNames = previousRequest.getHeaderNames();
-        if (headerNames == null) {
-            return;
-        }
-
-        HttpHeaders headers = request.getHeaders();
-        while (headerNames.hasMoreElements()) {
-            String headerName = headerNames.nextElement();
-            String headerValue = previousRequest.getHeader(headerName);
-            boolean isHeaderContains = isHeaderContainsExcludeInner(headerName.toLowerCase());
-            if (isHeaderContains) {
-                if (restTemplateCoreHeaderTransmissionEnabled) {
-                    headers.add(headerName, headerValue);
-                } else {
-                    boolean isCoreHeaderContains = StrategyUtil.isCoreHeaderContains(headerName);
-                    if (!isCoreHeaderContains) {
-                        headers.add(headerName, headerValue);
+        if (attributes != null) {
+            HttpServletRequest previousRequest = attributes.getRequest();
+            Enumeration<String> headerNames = previousRequest.getHeaderNames();
+            if (headerNames != null) {
+                HttpHeaders headers = request.getHeaders();
+                while (headerNames.hasMoreElements()) {
+                    String headerName = headerNames.nextElement();
+                    String headerValue = previousRequest.getHeader(headerName);
+                    boolean isHeaderContains = isHeaderContainsExcludeInner(headerName.toLowerCase());
+                    if (isHeaderContains) {
+                        if (restTemplateCoreHeaderTransmissionEnabled) {
+                            headers.add(headerName, headerValue);
+                        } else {
+                            boolean isCoreHeaderContains = StrategyUtil.isCoreHeaderContains(headerName);
+                            if (!isCoreHeaderContains) {
+                                headers.add(headerName, headerValue);
+                            }
+                        }
                     }
                 }
             }
         }
 
         if (restTemplateCoreHeaderTransmissionEnabled) {
+            HttpHeaders headers = request.getHeaders();
             if (CollectionUtils.isEmpty(headers.get(DiscoveryConstant.N_D_VERSION))) {
                 String routeVersion = serviceStrategyContextHolder.getRouteVersion();
                 if (StringUtils.isNotEmpty(routeVersion)) {


### PR DESCRIPTION
对于某个服务，如果不是http请求触发的代码，比如说是通过mq消息触发的代码，或者定时Task触发的代码，在非http请求触发的代码中无法获取灰度策略向后传递。