### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,13 +13,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 8.0.192, 8 ]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ matrix.java-version }} 
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
-        distribution: 'adopt'
+        java-version: ${{ matrix.java-version }} 
+        distribution: 'zulu'
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Also added are fixed (major) release version(s) such as `JDK 8.0.192`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 8`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 8.0.192` (fixed version) the build/tests passes (Green) and JDK 8 fails (Red) will mean that the latest `JDK 8` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.